### PR TITLE
Fix compatability with 0.24.0

### DIFF
--- a/ApolloAlamofire.podspec
+++ b/ApolloAlamofire.podspec
@@ -41,5 +41,5 @@ and solves known limitations of Apollo iOS library.
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
   s.dependency 'Alamofire', '~> 4.9.1'
-  s.dependency 'Apollo', '~> 0.19.0'
+  s.dependency 'Apollo', '~> 0.27.1'
 end

--- a/ApolloAlamofire/Classes/AlamofireTransport.swift
+++ b/ApolloAlamofire/Classes/AlamofireTransport.swift
@@ -38,7 +38,7 @@ public class AlamofireTransport: NetworkTransport {
 
   public func send<Operation>(
     operation: Operation,
-    completionHandler: @escaping (Swift.Result<GraphQLResponse<Operation>, Error>) -> ()
+    completionHandler: @escaping (Swift.Result<GraphQLResponse<Operation.Data>, Error>) -> ()
   )
     -> Cancellable where Operation: GraphQLOperation {
     let vars: JSONEncodable = operation.variables?.mapValues { $0?.jsonValue }
@@ -55,7 +55,7 @@ public class AlamofireTransport: NetworkTransport {
     }
     return request.responseJSON { response in
       let result = response.result
-        .flatMap { value -> GraphQLResponse<Operation> in
+        .flatMap { value -> GraphQLResponse<Operation.Data> in
           guard let value = value as? JSONObject else {
             throw response.error!
           }


### PR DESCRIPTION
Change `Operation` to `Operation.Data` in two places, and update the version in the podspec

I think [this is the change](https://github.com/apollographql/apollo-ios/commit/966a7546382eb7b9ceb9d28d50aaea173072f3e7) that broke it, or simultaneous with it.

I know you said you're deprecating this, but I don't know how to migrate to use the new equivalent features, so for now we're maintaining it this way, and I thought other people might be interested. If you know of a migration guide I'd love to see it so we can remove Alamofire in some places!